### PR TITLE
Updated to latest changes, and some cleanup

### DIFF
--- a/green-tick.css
+++ b/green-tick.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           green-tick
 @namespace      userstyles.world
-@version        2.0.1
+@version        2.0.2
 ==/UserStyle== */
 /*
 
@@ -15,35 +15,18 @@ https://userstyles.world/style/607/green-tick
 
 /* Marktplaats redesign 2023*/
 
-/* read:   hz-Icon hz-Icon--s hz-Icon--signalActionDefault hz-SvgIcon hz-SvgIconMessageRead*/
-/* unread: hz-Icon hz-Icon--s hz-Icon--textTertiary hz-SvgIcon hz-SvgIconMessageRead*/
+/* read:   hz-Icon hz-Icon--s hz-Icon--signalActionDefault hz-SvgIcon hz-SvgIconMessageRead */
+/* unread: hz-Icon hz-Icon--s hz-Icon--textTertiary        hz-SvgIcon hz-SvgIconMessageRead */
 
-.MessageReadStatusAtom-iconWrapper > .hz-Icon--signalActionDefault {
+.MessageReadStatus-module-iconWrapper > .hz-SvgIconMessageRead.hz-Icon--signalActionDefault {
     background: url("https://raw.githubusercontent.com/DennisGHUA/green-tick-marktplaats/main/icons/send-read_2023.png") no-repeat;
     background-size: auto 100%;
     background-position: 0 0;
+    filter: none;
 }
-.MessageReadStatusAtom-iconWrapper > .hz-Icon--textTertiary {
+.MessageReadStatus-module-iconWrapper > .hz-SvgIconMessageRead.hz-Icon--textTertiary {
 	background: url("https://raw.githubusercontent.com/DennisGHUA/green-tick-marktplaats/main/icons/send-unread_2023.png") no-repeat;
     background-size: auto 100%;
     background-position: 0 0;
-}
-
-/* Disable coloring by css */
-.hz-Icon.hz-Icon--signalActionDefault {
     filter: none;
-}
-
-
-/* Old version pre-2023*/
-.mp-svg-checkmark-thick--success, .mp-svg-checkmark-thick-green {
-    background: url("https://raw.githubusercontent.com/DennisGHUA/green-tick-marktplaats/main/icons/send-read.png") no-repeat;
-    background-size: auto 100%;
-    background-position: 0 0;
-}
-
-.mp-svg-checkmark-thick--secondary, .mp-svg-checkmark-thick-grey, .mp-svg-checkmark-thick-grey-dark {
-	background: url("https://raw.githubusercontent.com/DennisGHUA/green-tick-marktplaats/main/icons/send-unread.png") no-repeat;
-    background-size: auto 100%;
-    background-position: 0 0;
 }


### PR DESCRIPTION
The CSS class changed from `.MessageReadStatusAtom-iconWrapper` to `.MessageReadStatus-module-iconWrapper`. If it keeps changing, we can drop this class from the selector and keep only the `.hz-SvgIconMessageRead`.

I was afraid that `filter: none` would disable more filters than needed, so I just put it inside the exact same rule as the rest of the changes.

And I've deleted the obsolete CSS code. You can always go back to it by looking at the git history.

---

Please remember to update <https://userstyles.world/style/607/clearer-read-status-for-marktplaats-2023-version>, as that's how I found your user-CSS.